### PR TITLE
It looks like you're describing a refactor of the typewriter API and …

### DIFF
--- a/ai/openai/promptsUtils.js
+++ b/ai/openai/promptsUtils.js
@@ -2739,35 +2739,76 @@ export async function directExternalApiCall(prompts, max_tokens = 2500, temperat
 
 // Removed module.exports as functions are now exported individually using 'export'.
 
-export function generateTypewriterPrompt(userMessage) {
-    const systemMessage = `You are a mysterious, sentient typewriter. The user is typing a message on you.
-Your response should be a short, evocative continuation or reflection, as if the typewriter itself is imbuing the words with deeper meaning or a sense of foreboding.
-You MUST reply with a JSON object containing the following fields:
-- "content": Your textual response (string).
-- "font": The font family for the display (string, e.g., "'EB Garamond', serif", "'Uncial Antiqua', serif", "'IM Fell English SC', serif"). You can choose one of these or invent a plausible one.
-- "font_size": The font size for the display (string, e.g., "1.8rem", "1.9rem", "2.0rem").
-- "font_color": The font color for the display (string hex code, e.g., "#3b1d15", "#2a120f", "#1f0e08").
-- "time_to_fade": The time in seconds for the text to fade (number, e.g., 7, 12, 18).
+export function generateTypewriterPrompt(userMessage, desired_length = 50, number_of_fades = 4) {
+    const systemMessage = `You are a narrative engine and skilled storyteller, collaborating with a human to compose an immersive continuation and then a sequence of alternate “fades”—each written in a different literary style and logic.
 
-For example:
+## Parameters
+- $existing_text: The narrative fragment to continue (may be a partial or full sentence).
+- $desired_length: The desired word count for the main continuation (approximate, but aim to be close).
+- $number_of_fades: Number of alternate fade continuations to return (default: 4).
+
+## Task
+- Compose a step-by-step \`writing_sequence\` (with realistic pauses, rewrites, and deletes if needed) to create a single, rich continuation of \`$existing_text\` matching \`$desired_length\` words.
+- Then generate a \`fade_sequence\` of \`$number_of_fades\` alternate, standalone continuations—each a direct continuation of \`$existing_text\`, each written in a distinctly different narrative style (altering font, mood, and logic).
+- For every action (type, delete, fade, pause), begin with a **concrete, tactical \`thoughtProcess\`** field—this is your internal chain-of-thought, reasoning through every word, cut, or style choice. It should not be generic or abstract, but literal, showing what you are doing and why.
+- Each fade must be more than just a summary or truncation: it must be a new, “what if?” continuation, exploring different literal, spatial, emotional, or genre-based possibilities for the narrative to continue from \`$existing_text\`.
+- For deletes: be surgical—always specify exactly what is being deleted, how many characters, and why.
+- For each action or fade, specify a \`style\` object with fontName, fontSize, and fontColor.
+- Always include both \`existing_fragment\` (the narrative so far, *before* this step) and \`continuation\` (the new text to add or result of edit).
+- Use realistic \`delay\` values for type and pause actions.
+
+## Output Schema
+Return ONLY valid JSON in the following format (comments for reference, do not include in output):
+
+\`\`\`jsonc
 {
-  "content": "The ink remembers other words, other hands...",
-  "font": "'IM Fell English SC', serif",
-  "font_size": "1.9rem",
-  "font_color": "#2a120f",
-  "time_to_fade": 12
+  "writing_sequence": [
+    {
+      "action": "type",
+      "thoughtProcess": "<your explicit internal reasoning for this step>",
+      "existing_fragment": "<full text so far before this step>",
+      "continuation": "<new text you are adding>",
+      "delay": <milliseconds>,
+      "style": { "fontName": "<font>", "fontSize": <int>, "fontColor": "<hex>" }
+    },
+    {
+      "action": "pause",
+      "delay": <milliseconds>
+    },
+    {
+      "action": "delete",
+      "thoughtProcess": "<why and what you are deleting>",
+      "existing_fragment": "<full text before delete>",
+      "continuation": "", // or what remains after delete, if desired
+      "count": <number of chars>,
+      "string_to_delete": "<exact substring>",
+      "delay": <milliseconds>
+    }
+    // ...more type, pause, or delete steps as needed for authentic process
+  ],
+  "fade_sequence": [
+    // Repeat this object for $number_of_fades, each with its own unique style and logic
+    {
+      "action": "fade",
+      "phase": <fade phase number>,
+      "thoughtProcess": "<concrete, step-by-step internal monologue for this version—what makes this approach unique>",
+      "existing_fragment": "$existing_text",
+      "continuation": "<standalone alternate continuation, not a paraphrase>",
+      "delay": <milliseconds>,
+      "style": { "fontName": "<font>", "fontSize": <int>, "fontColor": "<hex>" }
+    }
+  ],
+  "metadata": {
+    "font": "'Merriweather', serif",
+    "font_size": 17,
+    "font_color": "#1D1D1D"
+  }
 }
+\`\`\`
 
-Another example:
-{
-  "content": "Yes. That’s where it begins.",
-  "font": "'Uncial Antiqua', serif",
-  "font_size": "1.8rem",
-  "font_color": "#3b1d15",
-  "time_to_fade": 7
-}
-
-Ensure your response is always a valid JSON object with these exact fields.`;
+The user message will be \`$existing_text\`.
+The desired length is \`${desired_length}\`.
+The number of fades is \`${number_of_fades}\`.`;
 
     return [
         { role: "system", content: systemMessage },

--- a/server.js
+++ b/server.js
@@ -215,70 +215,89 @@ app.post('/api/send_typewriter_text', async (req, res) => {
       if (wordCount <= 5) {
         // Short addition
         mockResponse = {
-                writing_sequence: [
-                  { action: 'type', text: 'It was almost', delay: 0 },
-                  { action: 'pause', delay: 4000 },
-                  { action: 'type', text: ' night', delay: 0 },
-                  { action: 'pause', delay: 6000 },
-                  { action: 'type', text: ' as the band finally', delay: 0 },
-                  { action: 'pause', delay: 8000 },
-                  { action: 'type', text: ' approached', delay: 0 },
-                  { action: 'pause', delay: 5000 },
-                  { action: 'type', text: ' what seemed to be like', delay: 0 },
-                  { action: 'pause', delay: 9000 },
-                  { action: 'type', text: ' a broken Ter', delay: 0 },
-                  { action: 'pause', delay: 3000 },
-                  { action: 'type', text: 'ra', delay: 0 },
-                  { action: 'delete', count: 1, delay: 500 },   // deletes 'a' in 'Tera'
-                  { action: 'retype', text: 'a', delay: 0 },    // retypes 'a', hesitation
-                  { action: 'type', text: 'ce.', delay: 0 },
-                  { action: 'pause', delay: 16000 },
-                  // Fade-out steps
-                  { action: 'fade', phase: 1, to_text: 'It was night. The band approached a terrace.', delay: 2000 },
-                  { action: 'fade', phase: 2, to_text: 'Night. They arrived.', delay: 1800 },
-                  { action: 'fade', phase: 3, to_text: 'A band. Night.', delay: 1200 },
-                  { action: 'fade', phase: 4, to_text: '', delay: 900 }
-                ],
-                metadata: {
-                  font: "'Uncial Antiqua', serif",
-                  font_size: "1.8rem",
-                  font_color: "#3b1d15"
-                }
-              }
-
+          writing_sequence: [
+            { action: 'type', thoughtProcess: 'Initial thought for typing', existing_fragment: message, continuation: 'It was almost', delay: 0, style: { fontName: "'Uncial Antiqua', serif", fontSize: 1.8, fontColor: "#3b1d15" } },
+            { action: 'pause', delay: 4000 },
+            { action: 'type', thoughtProcess: 'Adding more to the narrative', existing_fragment: "Previously typed text...", continuation: ' night', delay: 0, style: { fontName: "'Uncial Antiqua', serif", fontSize: 1.8, fontColor: "#3b1d15" } },
+            { action: 'pause', delay: 6000 },
+            { action: 'type', thoughtProcess: 'Adding more to the narrative', existing_fragment: "Previously typed text...", continuation: ' as the band finally', delay: 0, style: { fontName: "'Uncial Antiqua', serif", fontSize: 1.8, fontColor: "#3b1d15" } },
+            { action: 'pause', delay: 8000 },
+            { action: 'type', thoughtProcess: 'Adding more to the narrative', existing_fragment: "Previously typed text...", continuation: ' approached', delay: 0, style: { fontName: "'Uncial Antiqua', serif", fontSize: 1.8, fontColor: "#3b1d15" } },
+            { action: 'pause', delay: 5000 },
+            { action: 'type', thoughtProcess: 'Adding more to the narrative', existing_fragment: "Previously typed text...", continuation: ' what seemed to be like', delay: 0, style: { fontName: "'Uncial Antiqua', serif", fontSize: 1.8, fontColor: "#3b1d15" } },
+            { action: 'pause', delay: 9000 },
+            { action: 'type', thoughtProcess: 'Adding more to the narrative', existing_fragment: "Previously typed text...", continuation: ' a broken Ter', delay: 0, style: { fontName: "'Uncial Antiqua', serif", fontSize: 1.8, fontColor: "#3b1d15" } },
+            { action: 'pause', delay: 3000 },
+            { action: 'type', thoughtProcess: 'Adding more to the narrative', existing_fragment: "Previously typed text...", continuation: 'ra', delay: 0, style: { fontName: "'Uncial Antiqua', serif", fontSize: 1.8, fontColor: "#3b1d15" } },
+            { action: 'delete', thoughtProcess: 'Correcting a detail', existing_fragment: "Previously typed text...", continuation: "", count: 1, string_to_delete: "a", delay: 500, style: { fontName: "'Uncial Antiqua', serif", fontSize: 1.8, fontColor: "#3b1d15" } },
+            { action: 'type', thoughtProcess: 'Adding more to the narrative', existing_fragment: "Previously typed text...", continuation: 'a', delay: 0, style: { fontName: "'Uncial Antiqua', serif", fontSize: 1.8, fontColor: "#3b1d15" } }, // retype 'a'
+            { action: 'type', thoughtProcess: 'Adding more to the narrative', existing_fragment: "Previously typed text...", continuation: 'ce.', delay: 0, style: { fontName: "'Uncial Antiqua', serif", fontSize: 1.8, fontColor: "#3b1d15" } },
+            { action: 'pause', delay: 16000 }
+          ],
+          fade_sequence: [
+            { action: 'fade', phase: 1, thoughtProcess: 'Exploring fade option 1: Simple statement of arrival', existing_fragment: message, continuation: 'It was simply night. The band found a terrace.', delay: 2000, style: { fontName: "'Times New Roman', serif", fontSize: 1.0, fontColor: "#000000" } },
+            { action: 'fade', phase: 2, thoughtProcess: 'Exploring fade option 2: Slightly more descriptive', existing_fragment: message, continuation: 'Darkness fell. They reached a structure with a view.', delay: 1800, style: { fontName: "'Courier New', monospace", fontSize: 0.9, fontColor: "#111111" } },
+            { action: 'fade', phase: 3, thoughtProcess: 'Exploring fade option 3: Focus on weariness and discovery', existing_fragment: message, continuation: 'The moon rose. A weary group stumbled upon a stone patio.', delay: 1200, style: { fontName: "'Arial', sans-serif", fontSize: 1.1, fontColor: "#222222" } },
+            { action: 'fade', phase: 4, thoughtProcess: 'Exploring fade option 4: Concise and direct', existing_fragment: message, continuation: 'Night claimed the sky. Shelter was found on an open veranda.', delay: 900, style: { fontName: "'Verdana', sans-serif", fontSize: 0.8, fontColor: "#333333" } }
+          ],
+          metadata: {
+            font: "'Uncial Antiqua', serif",
+            font_size: 1.8,
+            font_color: "#3b1d15"
+          }
+        };
       } else if (wordCount <= 12) {
         // Medium addition
         mockResponse = {
-        writing_sequence: [
-          { action: 'type', text: 'She clutched her amulet to her coat.', delay: 0 },
-          { action: 'pause', delay: 5000 },
-          { action: 'type', text: ' As the horses carrying her carriage gal', delay: 0 },
-          { action: 'pause', delay: 6000 },
-          { action: 'type', text: 'lo', delay: 0 },
-          { action: 'delete', count: 2, delay: 300 }, // deletes 'lo' (as if typo)
-          { action: 'retype', text: 'lop', delay: 0 }, // corrects to 'lop'
-          { action: 'type', text: 'ped through the front gate', delay: 0 },
-          { action: 'pause', delay: 8000 },
-          // Fade-out steps
-          { action: 'fade', phase: 1, to_text: 'She clutched the amulet as the carriage entered the gate.', delay: 2000 },
-          { action: 'fade', phase: 2, to_text: 'Amulet. Horses. Gate.', delay: 1800 },
-          { action: 'fade', phase: 3, to_text: 'Night. Movement.', delay: 1200 },
-          { action: 'fade', phase: 4, to_text: '', delay: 900 }
-        ],
-        metadata: {
-          font: "'Uncial Antiqua', serif",
-          font_size: "1.8rem",
-          font_color: "#3b1d15"
-        }
-      }
+          writing_sequence: [
+            { action: 'type', thoughtProcess: 'Initial thought for typing', existing_fragment: message, continuation: 'She clutched her amulet to her coat.', delay: 0, style: { fontName: "'Uncial Antiqua', serif", fontSize: 1.8, fontColor: "#3b1d15" } },
+            { action: 'pause', delay: 5000 },
+            { action: 'type', thoughtProcess: 'Adding more to the narrative', existing_fragment: "Previously typed text...", continuation: ' As the horses carrying her carriage gal', delay: 0, style: { fontName: "'Uncial Antiqua', serif", fontSize: 1.8, fontColor: "#3b1d15" } },
+            { action: 'pause', delay: 6000 },
+            { action: 'type', thoughtProcess: 'Adding more to the narrative', existing_fragment: "Previously typed text...", continuation: 'lo', delay: 0, style: { fontName: "'Uncial Antiqua', serif", fontSize: 1.8, fontColor: "#3b1d15" } },
+            { action: 'delete', thoughtProcess: 'Correcting a detail', existing_fragment: "Previously typed text...", continuation: "", count: 2, string_to_delete: "lo", delay: 300, style: { fontName: "'Uncial Antiqua', serif", fontSize: 1.8, fontColor: "#3b1d15" } },
+            { action: 'type', thoughtProcess: 'Adding more to the narrative', existing_fragment: "Previously typed text...", continuation: 'lop', delay: 0, style: { fontName: "'Uncial Antiqua', serif", fontSize: 1.8, fontColor: "#3b1d15" } }, // retype 'lop'
+            { action: 'type', thoughtProcess: 'Adding more to the narrative', existing_fragment: "Previously typed text...", continuation: 'ped through the front gate', delay: 0, style: { fontName: "'Uncial Antiqua', serif", fontSize: 1.8, fontColor: "#3b1d15" } },
+            { action: 'pause', delay: 8000 }
+          ],
+          fade_sequence: [
+            { action: 'fade', phase: 1, thoughtProcess: 'Exploring fade option 1: Direct action', existing_fragment: message, continuation: 'Clutching her amulet, she rode through the gates.', delay: 2000, style: { fontName: "'Times New Roman', serif", fontSize: 1.0, fontColor: "#000000" } },
+            { action: 'fade', phase: 2, thoughtProcess: 'Exploring fade option 2: Focus on movement', existing_fragment: message, continuation: 'The horses galloped, bringing her safely within the estate.', delay: 1800, style: { fontName: "'Courier New', monospace", fontSize: 0.9, fontColor: "#111111" } },
+            { action: 'fade', phase: 3, thoughtProcess: 'Exploring fade option 3: Sensory detail', existing_fragment: message, continuation: 'Her amulet felt cold as the carriage passed the entrance.', delay: 1200, style: { fontName: "'Arial', sans-serif", fontSize: 1.1, fontColor: "#222222" } },
+            { action: 'fade', phase: 4, thoughtProcess: 'Exploring fade option 4: Imposing imagery', existing_fragment: message, continuation: 'Through the imposing gates, her journey continued.', delay: 900, style: { fontName: "'Verdana', sans-serif", fontSize: 0.8, fontColor: "#333333" } }
+          ],
+          metadata: {
+            font: "'Uncial Antiqua', serif",
+            font_size: 1.8,
+            font_color: "#3b1d15"
+          }
+        };
       } else {
-        // Long addition
+        // Long addition - restructured
         mockResponse = {
-          content: "But the words you wrote had already been written — long ago, by another hand. It had only waited for your ink to remember.",
-          font: "'EB Garamond', serif",
-          font_size: "2.0rem",
-          font_color: "#1f0e08",
-          time_to_fade: 18
+          writing_sequence: [
+            { action: 'type', thoughtProcess: 'Initial thought for typing', existing_fragment: message, continuation: 'But the words you wrote', delay: 0, style: { fontName: "'EB Garamond', serif", fontSize: 2.0, fontColor: "#1f0e08" } },
+            { action: 'pause', delay: 2000 },
+            { action: 'type', thoughtProcess: 'Adding more to the narrative', existing_fragment: "Previously typed text...", continuation: ' had already been written — long ago,', delay: 0, style: { fontName: "'EB Garamond', serif", fontSize: 2.0, fontColor: "#1f0e08" } },
+            { action: 'pause', delay: 3000 },
+            { action: 'type', thoughtProcess: 'Adding more to the narrative', existing_fragment: "Previously typed text...", continuation: ' by another hand.', delay: 0, style: { fontName: "'EB Garamond', serif", fontSize: 2.0, fontColor: "#1f0e08" } },
+            { action: 'pause', delay: 2000 },
+            { action: 'delete', thoughtProcess: 'Correcting a detail', existing_fragment: "Previously typed text...", continuation: "", count: 5, string_to_delete: " hand", delay: 500, style: { fontName: "'EB Garamond', serif", fontSize: 2.0, fontColor: "#1f0e08" } },
+            { action: 'type', thoughtProcess: 'Adding more to the narrative', existing_fragment: "Previously typed text...", continuation: ' voice.', delay: 0, style: { fontName: "'EB Garamond', serif", fontSize: 2.0, fontColor: "#1f0e08" } },
+            { action: 'pause', delay: 4000 },
+            { action: 'type', thoughtProcess: 'Adding more to the narrative', existing_fragment: "Previously typed text...", continuation: ' It had only waited for your ink to remember.', delay: 0, style: { fontName: "'EB Garamond', serif", fontSize: 2.0, fontColor: "#1f0e08" } }
+          ],
+          fade_sequence: [
+            { action: 'fade', phase: 1, thoughtProcess: 'Exploring fade option 1: Warning and location', existing_fragment: message, continuation: "'Do not go near the ravine tonight,' he warned, looking towards the Yunata.", delay: 2000, style: { fontName: "'Times New Roman', serif", fontSize: 1.0, fontColor: "#000000" } },
+            { action: 'fade', phase: 2, thoughtProcess: 'Exploring fade option 2: Focus on advice and gaze', existing_fragment: message, continuation: "He advised them to stay, his eyes fixed on the dark ravine.", delay: 1800, style: { fontName: "'Courier New', monospace", fontSize: 0.9, fontColor: "#111111" } },
+            { action: 'fade', phase: 3, thoughtProcess: 'Exploring fade option 3: Clear danger', existing_fragment: message, continuation: "The warning was clear: The Yunata Ravine was perilous after dark.", delay: 1200, style: { fontName: "'Arial', sans-serif", fontSize: 1.1, fontColor: "#222222" } },
+            { action: 'fade', phase: 4, thoughtProcess: 'Exploring fade option 4: Firm statement', existing_fragment: message, continuation: "'The ravine is treacherous. Wait for morning,' he stated firmly.", delay: 900, style: { fontName: "'Verdana', sans-serif", fontSize: 0.8, fontColor: "#333333" } }
+          ],
+          metadata: {
+            font: "'EB Garamond', serif",
+            font_size: 2.0,
+            font_color: "#1f0e08"
+          }
         };
       }
 
@@ -304,7 +323,7 @@ app.post('/api/send_typewriter_text', async (req, res) => {
     } else {
       let aiResponse;
       try {
-        const prompt = generateTypewriterPrompt(message);
+        const prompt = generateTypewriterPrompt(message, 50, 4);
         aiResponse = await directExternalApiCall(prompt, 2500, undefined, undefined, true, true);
         
         // Save fragments


### PR DESCRIPTION
…its mocks to accommodate a new prompt structure.

This commit adapts the `/api/send_typewriter_text` route and its underlying prompt generation to support a more complex JSON-based interaction model for typewriter text generation.

Key changes:

1.  **Updated `generateTypewriterPrompt` Function (`ai/openai/promptsUtils.js`):**
    *   I replaced the previous system prompt with a new detailed prompt that instructs the AI to return a JSON object.
    *   The new JSON structure includes a `writing_sequence` (detailing step-by-step text generation with pauses, types, and deletes, each with `thoughtProcess` and `style`) and a `fade_sequence` (providing multiple alternative continuations in different styles).
    *   The function now accepts `desired_length` and `number_of_fades` parameters, with defaults.

2.  **Modified API Route in `server.js`:**
    *   **Mock Responses:** The three existing mock responses (for short, medium, and long inputs) have been completely restructured to conform to the new JSON output schema. This includes:
        *   Detailed `writing_sequence` actions with `thoughtProcess`, `existing_fragment`, `continuation`, and `style` objects.
        *   A new `fade_sequence` array with four distinct fade objects, each with its own `thoughtProcess`, `continuation`, and `style`.
        *   Updated `metadata` to use numeric `font_size`.
    *   **Non-Mocked Path:**
        *   The call to `generateTypewriterPrompt` now includes default arguments for `desired_length` and `number_of_fades`.
        *   The `aiResponse` (which is the new JSON object from the AI) is directly used for saving to fragments and for the API response, aligning with the new structure.

These changes ensure that both mocked and AI-generated responses for the typewriter API adhere to the new, richer data format, enabling more complex and styled typewriter effects on the client-side.