### PR TITLE
Add mock response for generateTexturesPostHandler

### DIFF
--- a/ai/textToImage/mocks.js
+++ b/ai/textToImage/mocks.js
@@ -65,11 +65,71 @@ const optionsMock = {
 
     const mockedTextureOptionsPrompts = [{prompt: 'texturePrompt1', font: 'font1'}, {prompt: 'texturePrompt2', font: 'font2'},{prompt: 'texturePrompt3', font: 'font3'},{prompt: 'texturePrompt4', font: 'font4'}]
 
+const mockGenerateTexturesResponse = {
+  cards: [
+    {
+      url: {
+        revised_prompt: "Example revised prompt for image generation.",
+        url: "https://example.com/image.png", // Placeholder image URL
+        localPath: "/path/to/local/image.png" // Placeholder local path
+      },
+      entity: {
+        name: "Example Entity Name",
+        ner_type: "Example NER Type",
+        ner_subtype: "Example NER Subtype",
+        description: "Detailed description of the example entity.",
+        relevance: "Relevance of this entity to the story or context.",
+        evolution_notes: "Notes on how this entity might evolve or change.",
+        connections: [
+          { entity: "Another Entity", type: "connection_type" }
+        ]
+      },
+      selectedTexture: {
+        prompt: "Example texture prompt.",
+        font: "Example Font",
+        card_material: "Example Card Material",
+        major_cultural_influences_references: ["Influence 1", "Influence 2"],
+        localPath: "/path/to/local/texture.png", // Placeholder local path for texture
+        id: 0, // Example ID
+        text_for_entity: "Example Entity Name" // Should match entity.name
+      }
+    },
+    {
+      url: {
+        revised_prompt: "Second example revised prompt for image generation.",
+        url: "https://example.com/image2.png", // Placeholder image URL
+        localPath: "/path/to/local/image2.png" // Placeholder local path
+      },
+      entity: {
+        name: "Second Example Entity Name",
+        ner_type: "Second Example NER Type",
+        ner_subtype: "Second Example NER Subtype",
+        description: "Detailed description of the second example entity.",
+        relevance: "Relevance of this second entity to the story or context.",
+        evolution_notes: "Notes on how this second entity might evolve or change.",
+        connections: [
+          { entity: "Third Entity", type: "another_connection_type" }
+        ]
+      },
+      selectedTexture: {
+        prompt: "Second example texture prompt.",
+        font: "Second Example Font",
+        card_material: "Second Example Card Material",
+        major_cultural_influences_references: ["Influence 3", "Influence 4"],
+        localPath: "/path/to/local/texture2.png", // Placeholder local path for texture
+        id: 1, // Example ID
+        text_for_entity: "Second Example Entity Name" // Should match entity.name
+      }
+    }
+  ]
+};
+
     module.exports = {
         optionsMock,
         fragment,
         userResponses,
         mockedStorytellerResponses,
-        mockedTextureOptionsPrompts
+        mockedTextureOptionsPrompts,
+        mockGenerateTexturesResponse
     };
     

--- a/server.js
+++ b/server.js
@@ -37,6 +37,7 @@ import {
     developEntity, // Added for developEntityPostHandler
     generateTextureOptionsByText // Added for generateTexturesPostHandler
 } from './ai/textToImage/api.js';
+import { mockGenerateTexturesResponse } from './ai/textToImage/mocks.js';
 
 
 // Configuration from environment variables
@@ -45,6 +46,7 @@ const NARRATION_MOCK_MODE = process.env.NARRATION_MOCK_MODE === 'true';
 const STORYTELLING_DEMO_MODE = process.env.STORYTELLING_DEMO_MODE === 'true'; // For /api/storytelling2
 const PREFIX_MOCK_MODE = process.env.PREFIX_MOCK_MODE === 'true'; // For /api/prefixes (already correct)
 const TYPEWRITER_MOCK_MODE = process.env.TYPEWRITER_MOCK_MODE === 'true';
+const SHOULD_MOCK_GENERATE_TEXTURES = true;
 
 
 const __filename = fileURLToPath(import.meta.url);
@@ -838,6 +840,11 @@ app.post('/api/generateEntities', generateEntitiesPostHandler);
 const generateTexturesPostHandler = async (req, res) => {
   try {
     const { userText, sessionId } = req.body;
+
+    if (SHOULD_MOCK_GENERATE_TEXTURES) {
+      console.log('Serving mock response for /api/generateTextures');
+      return res.json(mockGenerateTexturesResponse);
+    }
 
     if (!sessionId || userText === undefined) { 
       return res.status(400).json({ message: 'Missing required parameters: sessionId or userText.' });


### PR DESCRIPTION
I've created a mock JSON response for the `/api/generateTextures` endpoint. The mock is named `mockGenerateTexturesResponse` and I've added it to `ai/textToImage/mocks.js`.

This mock simulates the expected output structure, including an array of cards, each with URL, entity, and selectedTexture details. This will be useful for your frontend development and testing purposes.