### PR TITLE
feat: Add Storyteller MongoDB collection and CRUD operations

### DIFF
--- a/models/models.js
+++ b/models/models.js
@@ -65,3 +65,23 @@ mongoose.connect('mongodb://localhost:27017/storytelling', {
 export const ChatMessage = mongoose.model('ChatMessage', chatMessageSchema);
 export const NarrativeFragment = mongoose.model('NarrativeFragment', narrativeFragmentSchema);
 export const SessionVector = mongoose.model('SessionVector', SessionVectorSchema);
+
+const StorytellerSchema = new mongoose.Schema({
+  name: { type: String, required: true, unique: true },
+  immediate_ghost_appearance: { type: String },
+  typewriter_key: {
+    symbol: { type: String },
+    description: { type: String },
+  },
+  influences: { type: [String] },
+  known_universes: { type: [String] },
+  level: { type: Number },
+  voice_creation: {
+    voice: { type: String },
+    age: { type: String },
+    style: { type: String },
+  },
+  vector: { type: [Number] },
+}, { timestamps: true });
+
+export const Storyteller = mongoose.model('Storyteller', StorytellerSchema);

--- a/storyteller/db/mock_storytellers.json
+++ b/storyteller/db/mock_storytellers.json
@@ -1,0 +1,75 @@
+[
+  {
+    "name": "Ada the Lantern-Bearer",
+    "immediate_ghost_appearance": "A pale woman in oilskin, flickering at the edge of the page; a gust of salt wind and the hiss of a lantern.",
+    "typewriter_key": {
+      "symbol": "lantern",
+      "description": "An old brass lantern engraved on the keycap, emitting a gentle golden glow."
+    },
+    "influences": [
+      "Emily Dickinson",
+      "Gene Wolfe",
+      "Night Witches RPG",
+      "The Expanse (TV)",
+      "Dreamland cycles"
+    ],
+    "known_universes": [
+      "The Drowned Library",
+      "Echoes of Mars",
+      "Portents in Fog"
+    ],
+    "level": 14,
+    "voice_creation": {
+      "voice": "female",
+      "age": "late 20s",
+      "style": "calm, luminous, clipped consonants, faint echo"
+    }
+  },
+  {
+    "name": "The Greasehand",
+    "immediate_ghost_appearance": "A hulking silhouette spattered in machine oil; gears click in the dark as fingers hover over blank keys.",
+    "typewriter_key": {
+      "symbol": "wrench",
+      "description": "A miniature wrench hammered into the side of an otherwise normal typewriter key."
+    },
+    "influences": [
+      "China Miéville",
+      "Industrial Revolution pamphlets",
+      "Degenesis RPG"
+    ],
+    "known_universes": [
+      "Brass and Bone",
+      "The Nettle Yard"
+    ],
+    "level": 7,
+    "voice_creation": {
+      "voice": "male",
+      "age": "40s",
+      "style": "gruff, mechanical undertones, slow pace"
+    }
+  },
+  {
+    "name": "Tess of the Silent Quarter",
+    "immediate_ghost_appearance": "A barely-seen girl in a velvet cloak, reading the room’s shadows; her words emerge in a hush, barely brushing the page.",
+    "typewriter_key": {
+      "symbol": "crescent moon",
+      "description": "A sliver of mother-of-pearl forms a crescent inlaid on the key; faint luminescence in low light."
+    },
+    "influences": [
+      "Franz Kafka",
+      "Angela Carter",
+      "Unknown Armies",
+      "Tales from the Loop"
+    ],
+    "known_universes": [
+      "Nocturne Alley",
+      "Hushed City"
+    ],
+    "level": 5,
+    "voice_creation": {
+      "voice": "female",
+      "age": "17",
+      "style": "whispery, uncertain, with a trace of awe"
+    }
+  }
+]

--- a/storyteller/utils.js
+++ b/storyteller/utils.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import mongoose from 'mongoose';
 import * as fsPromises from 'fs/promises';
-import { NarrativeFragment, ChatMessage } from '../models/models.js';
+import { NarrativeFragment, ChatMessage, Storyteller } from '../models/models.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -1092,7 +1092,72 @@ export async function storytellerDetectiveFirstParagraphCreation(sessionId, user
 
 // module.exports removed, functions are exported individually.
 
+// Storyteller CRUD functions
+export async function createStoryteller(storytellerData) {
+  try {
+    const storyteller = new Storyteller(storytellerData);
+    await storyteller.save();
+    return storyteller;
+  } catch (error) {
+    console.error("Error creating storyteller:", error);
+    throw error;
+  }
+}
 
+export async function findStoryteller(query) {
+  try {
+    const storytellers = await Storyteller.find(query);
+    return storytellers;
+  } catch (error) {
+    console.error("Error finding storytellers:", error);
+    throw error;
+  }
+}
+
+export async function findStorytellerByName(name) {
+  try {
+    const storyteller = await Storyteller.findOne({ name: name });
+    return storyteller;
+  } catch (error) {
+    console.error("Error finding storyteller by name:", error);
+    throw error;
+  }
+}
+
+export async function updateStoryteller(name, updates) {
+  try {
+    // Ensure `updatedAt` is set, Mongoose does this by default with {timestamps: true}
+    const storyteller = await Storyteller.findOneAndUpdate({ name: name }, updates, { new: true });
+    return storyteller;
+  } catch (error) {
+    console.error("Error updating storyteller:", error);
+    throw error;
+  }
+}
+
+export async function deleteStoryteller(name) {
+  try {
+    const result = await Storyteller.findOneAndDelete({ name: name });
+    return result || { message: "Storyteller not found or already deleted." };
+  } catch (error) {
+    console.error("Error deleting storyteller:", error);
+    throw error;
+  }
+}
+
+export async function upsertStoryteller(storytellerData) {
+  try {
+    const storyteller = await Storyteller.findOneAndUpdate(
+      { name: storytellerData.name },
+      storytellerData,
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
+    return storyteller;
+  } catch (error) {
+    console.error("Error upserting storyteller:", error);
+    throw error;
+  }
+}
 
 // "step_number": 4,
 // "step_title": "Location Element",

--- a/storyteller/utils.test.js
+++ b/storyteller/utils.test.js
@@ -1,6 +1,51 @@
 import mongoose from 'mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
-import { setFragment, NarrativeFragment } from './utils.js'; // Assuming utils.js is in the same directory
+import {
+  setFragment,
+  NarrativeFragment,
+  createStoryteller,
+  findStoryteller,
+  findStorytellerByName,
+  updateStoryteller,
+  deleteStoryteller,
+  upsertStoryteller
+} from './utils.js'; // Assuming utils.js is in the same directory
+
+// Mock the Storyteller model from models/models.js
+const mockStorytellerSave = jest.fn();
+const mockStorytellerCreate = jest.fn();
+const mockStorytellerFind = jest.fn();
+const mockStorytellerFindOne = jest.fn();
+const mockStorytellerFindOneAndUpdate = jest.fn();
+const mockStorytellerDeleteOne = jest.fn(); // Corrected from findOneAndDelete to deleteOne if that's what's used
+
+jest.mock('../models/models.js', () => ({
+  NarrativeFragment: mongoose.model('NarrativeFragment', new mongoose.Schema({ // Real schema for NarrativeFragment
+    session_id: { type: String, required: true },
+    fragment: { type: mongoose.Schema.Types.Mixed, required: true },
+    turn: { type: Number },
+    createdAt: { type: Date, default: Date.now }
+  })),
+  Storyteller: jest.fn().mockImplementation(function(data) { // Mocked Storyteller
+    return {
+      ...data,
+      save: mockStorytellerSave.mockResolvedValue(data), // Ensure save returns the data
+    };
+  }),
+  // If ChatMessage is also used by other utility functions and needs a real model for tests:
+  ChatMessage: mongoose.model('ChatMessage', new mongoose.Schema({ /* ... define schema if needed ... */ })),
+}));
+
+// Static methods for Storyteller mock
+// Storyteller.create = mockStorytellerCreate; // This line was causing issues, create is not a static method of the class itself but of the model.
+// Correct way to mock static methods on a class mock:
+const Storyteller = require('../models/models.js').Storyteller; // get the mocked constructor
+Storyteller.create = mockStorytellerCreate;
+Storyteller.find = mockStorytellerFind;
+Storyteller.findOne = mockStorytellerFindOne;
+Storyteller.findOneAndUpdate = mockStorytellerFindOneAndUpdate;
+Storyteller.deleteOne = mockStorytellerDeleteOne; // Corrected this line
+Storyteller.findOneAndDelete = mockStorytellerDeleteOne; // If findOneAndDelete is preferred
 
 let mongoServer;
 
@@ -8,8 +53,8 @@ beforeAll(async () => {
   mongoServer = await MongoMemoryServer.create();
   const mongoUri = mongoServer.getUri();
   await mongoose.connect(mongoUri, {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
+    // useNewUrlParser: true, // Deprecated
+    // useUnifiedTopology: true, // Deprecated
   });
 });
 
@@ -21,6 +66,13 @@ afterAll(async () => {
 afterEach(async () => {
   // Clear data from the NarrativeFragment collection after each test
   await NarrativeFragment.deleteMany({});
+  // Clear all mock function calls after each test
+  mockStorytellerSave.mockClear();
+  mockStorytellerCreate.mockClear();
+  mockStorytellerFind.mockClear();
+  mockStorytellerFindOne.mockClear();
+  mockStorytellerFindOneAndUpdate.mockClear();
+  mockStorytellerDeleteOne.mockClear();
 });
 
 describe('setFragment', () => {
@@ -137,5 +189,77 @@ describe('NarrativeFragment Model', () => {
     expect(error).toBeInstanceOf(mongoose.Error.ValidationError);
     expect(error.errors.session_id).toBeDefined();
     expect(error.errors.fragment).toBeDefined();
+  });
+});
+
+// Tests for Storyteller CRUD functions
+describe('Storyteller CRUD operations', () => {
+  const storytellerData = { name: "Ada", level: 10 };
+  const storytellerName = "Ada";
+
+  describe('createStoryteller', () => {
+    it('should call Storyteller constructor and save', async () => {
+      // We need to mock the result of the save() call for the instance.
+      // The constructor is already mocked to return an object with a save method.
+      mockStorytellerSave.mockResolvedValueOnce(storytellerData); // Mock the save method for this specific test case
+
+      const result = await createStoryteller(storytellerData);
+      expect(Storyteller).toHaveBeenCalledWith(storytellerData);
+      expect(mockStorytellerSave).toHaveBeenCalled();
+      expect(result).toEqual(storytellerData);
+    });
+  });
+
+  describe('findStoryteller', () => {
+    it('should call Storyteller.find with the query', async () => {
+      const query = { level: { $gt: 5 } };
+      mockStorytellerFind.mockResolvedValueOnce([storytellerData]); // Mock the static find method
+
+      await findStoryteller(query);
+      expect(Storyteller.find).toHaveBeenCalledWith(query);
+    });
+  });
+
+  describe('findStorytellerByName', () => {
+    it('should call Storyteller.findOne with the name query', async () => {
+      mockStorytellerFindOne.mockResolvedValueOnce(storytellerData); // Mock the static findOne method
+
+      await findStorytellerByName(storytellerName);
+      expect(Storyteller.findOne).toHaveBeenCalledWith({ name: storytellerName });
+    });
+  });
+
+  describe('updateStoryteller', () => {
+    it('should call Storyteller.findOneAndUpdate with correct parameters', async () => {
+      const updates = { level: 11 };
+      const expectedOptions = { new: true };
+      mockStorytellerFindOneAndUpdate.mockResolvedValueOnce({ ...storytellerData, ...updates }); // Mock the static findOneAndUpdate
+
+      await updateStoryteller(storytellerName, updates);
+      expect(Storyteller.findOneAndUpdate).toHaveBeenCalledWith({ name: storytellerName }, updates, expectedOptions);
+    });
+  });
+
+  describe('deleteStoryteller', () => {
+    it('should call Storyteller.findOneAndDelete with the name query', async () => {
+      // Using findOneAndDelete as per the implementation, ensure mock matches
+      // If the implementation uses deleteOne, this should be Storyteller.deleteOne
+      Storyteller.findOneAndDelete = jest.fn().mockResolvedValueOnce(storytellerData); // Mock specifically for this test
+
+      await deleteStoryteller(storytellerName);
+      expect(Storyteller.findOneAndDelete).toHaveBeenCalledWith({ name: storytellerName });
+    });
+  });
+
+  describe('upsertStoryteller', () => {
+    const upsertData = { name: "Tess", level: 5, immediate_ghost_appearance: "A whisper" };
+
+    it('should call Storyteller.findOneAndUpdate for upsertion', async () => {
+      const expectedOptions = { upsert: true, new: true, setDefaultsOnInsert: true };
+      mockStorytellerFindOneAndUpdate.mockResolvedValueOnce(upsertData); // Mock the static findOneAndUpdate for upsert
+
+      await upsertStoryteller(upsertData);
+      expect(Storyteller.findOneAndUpdate).toHaveBeenCalledWith({ name: upsertData.name }, upsertData, expectedOptions);
+    });
   });
 });


### PR DESCRIPTION
Defines the schema and Mongoose model for a `storytellers` collection. Implements Create, Read, Update, Delete (CRUD) operations and an upsert function for managing storyteller profiles.

Key changes:
- Added `storytellerSchema` and `Storyteller` model to `models/models.js`. The schema includes fields such as name, immediate_ghost_appearance, typewriter_key, influences, known_universes, level, voice_creation, and vector. Timestamps (created_at, updated_at) are automatically managed.
- Implemented the following functions in `storyteller/utils.js`:
    - `createStoryteller(storytellerData)`
    - `findStoryteller(query)`
    - `findStorytellerByName(name)`
    - `updateStoryteller(name, updates)`
    - `deleteStoryteller(name)`
    - `upsertStoryteller(storytellerData)`
- Created `storyteller/db/mock_storytellers.json` with three sample storyteller documents for testing and development.
- Added unit tests for the new CRUD and upsert functions in `storyteller/utils.test.js`, using Mongoose model mocking.